### PR TITLE
Update MATLAB.gitignore

### DIFF
--- a/Global/MATLAB.gitignore
+++ b/Global/MATLAB.gitignore
@@ -26,5 +26,8 @@ codegen/
 # Cache files
 *.slxc
 
+# Buildtool cache folder
+.buildtool/
+
 # Cloud based storage dotfile
 .MATLABDriveTag


### PR DESCRIPTION
Added ignore for cached data produced by buildtool

**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->

I've been adding this to my .gitignore locally.  Probably should be in the global ignore.  



